### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ The initial, regular Tacotron model was trained first on LJSpeech, and then on a
 * The Forward Tacotron model was only trained on about 600 voice lines.
 * The HiFiGAN model was generated through transfer learning from the sample.
 * All models have been optimized and quantized.
+
+
+
+## Installation Instruction
+If you want to install the TTS Engine on your machine, please follow the steps
+below.
+
+1. Install the [`espeak`](https://github.com/espeak-ng/espeak-ng) synthesizer
+   according to the [installation
+   instructions](https://github.com/espeak-ng/espeak-ng/blob/master/docs/guide.md)
+   for your operating system.
+2. Install the required Python packages, e.g., by running `pip install -r
+   requirements.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+torch
+phonemizer
+inflect
+unidecode
+scipy


### PR DESCRIPTION
This PR adds some basic installation instructions to the README and it adds a [`requirements.txt`](requirements.txt) file which contains all Python packages which are required to run the [`glados.py`](glados.py) script.

This simplifies the installation process since one can simply run `pip install -r requirements.txt` to automatically install all required packages.