### PR TITLE
Added a script for downloading models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__/**
 *.wav
 audio/*
+.venv/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,43 @@ The initial, regular Tacotron model was trained first on LJSpeech, and then on a
 If you want to install the TTS Engine on your machine, please follow the steps
 below.
 
-1. Download the model files from [`Google Drive`](https://drive.google.com/file/d/1TRJtctjETgVVD5p7frSVPmgw8z8FFtjD/view?usp=sharing) and unzip into the repo folder
-2. Install the required Python packages, e.g., by running `pip install -r
-   requirements.txt`
+### Linux (bash)
+
+```bash
+# 1. Clone the project (Ignore errors if any): 
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/R2D2FISH/glados-tts && cd glados-tts
+# 2. Download the model files:
+python3 download.py
+# 3. Create a venv (Optional)
+python3 -m venv .venv && source .venv/bin/activate
+# 4. Install requirements
+pip install -r requirements.txt
+# 5. Run the program
+python3 glados-tts/glados.py
+# If you installed a venv dont forget to activate it using source .venv/bin/activate before running it next time
+```
+
+
+### Windows (cmd)
+
+```CMD
+:: 1. Set the GIT_LFS_SKIP_SMUDGE environment variable
+set GIT_LFS_SKIP_SMUDGE=1
+
+:: 2. Clone the project (Ignore errors if any): 
+git clone https://github.com/R2D2FISH/glados-tts
+cd glados-tts
+
+:: 3. Download the model files:
+python download.py
+
+:: 4. Create a venv (Optional)
+python -m venv .venv
+call .venv\Scripts\activate
+
+:: 5. Install requirements
+pip install -r requirements.txt
+
+:: 6. Run the program
+python glados-tts\glados.py
+```

--- a/download.py
+++ b/download.py
@@ -1,0 +1,86 @@
+"""Utility for downloading gladostts models"""
+import argparse
+import hashlib
+import logging
+import shutil
+from pathlib import Path
+from typing import Union
+from urllib.parse import quote, urlsplit, urlunsplit
+from urllib.request import urlopen
+
+DEFAULT_URL = "https://github.com/nalf3in/glados-tts/releases/download/v0.1.0-alpha/{file}"
+DEFAULT_MODEL_DIR = "./models"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _quote_url(url: str) -> str:
+    """Quote file part of URL in case it contains UTF-8 characters."""
+    parts = list(urlsplit(url))
+    parts[2] = quote(parts[2])
+    return urlunsplit(parts)
+
+
+def get_file_hash(path: Union[str, Path], bytes_per_chunk: int = 8192) -> str:
+    """Hash a file in chunks using md5."""
+    path_hash = hashlib.md5()
+    with open(path, "rb") as path_file:
+        chunk = path_file.read(bytes_per_chunk)
+        while chunk:
+            path_hash.update(chunk)
+            chunk = path_file.read(bytes_per_chunk)
+
+    return path_hash.hexdigest()
+
+
+def ensure_model_exists(download_dir: Union[str, Path]):
+    download_dir = Path(download_dir)
+
+    # Define the list of model files and their checksums
+    model_files = [
+        {"filename": "glados-new.pt", "md5": "d6945ffd96ee0619d0d49a581b5b83ad"},
+        {"filename": "glados.pt", "md5": "11383a00f7ddfc8f80285ce3aba2ebb0"},
+        {"filename": "en_us_cmudict_ipa_forward.pt", "md5": "33887f7f579f010ce4463534306120b0"},
+        {"filename": "emb/glados_p2.pt", "md5": "ff2ad1438e9acb1f8e8607864c239ffc"},
+        {"filename": "emb/glados_p1.pt", "md5": "e0ffe67a6f53c4ff0b3952fc678946d9"},
+        {"filename": "vocoder-gpu.pt", "md5": "d35c13c01d2cacd348aa216649bbfac3"},
+        {"filename": "vocoder-cpu-hq.pt", "md5": "e8842210dc989e351c2e50614ff55f46"},
+        {"filename": "vocoder-cpu-lq.pt", "md5": "cfd048af8bb8190995eac7b95bf7367e"},
+    ]
+
+    for model in model_files:
+        model_file = model["filename"]
+        model_file_path = download_dir / model_file
+        model_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # If file exists and is too small or has incorrect checksum, delete it
+        if model_file_path.exists():
+            md5_hash = get_file_hash(model_file_path)
+        
+            if model_file_path.stat().st_size < 1024:  
+                model_file_path.unlink()
+            elif md5_hash != model["md5"]:
+                _LOGGER.warning("WARNING md5 hash failed for %s, this file may be corrupted. md5: %s", model_file_path, md5_hash)
+
+        # If file does not exist (or was deleted), download it
+        if not model_file_path.exists():
+            try:
+                filename = model_file.split("/")[-1]
+                model_url = URL.format(file=filename)
+                _LOGGER.warning("Downloading %s to %s", model_url, model_file_path)
+                with urlopen(_quote_url(model_url)) as response, open(
+                    model_file_path, "wb"
+                ) as download_file:
+                    shutil.copyfileobj(response, download_file)
+                _LOGGER.info("Downloaded %s (%s)", model_file_path, model_url)
+            except:
+                _LOGGER.exception("Unexpected error while downloading file: %s\nURL: %s", model_file, _quote_url(model_url))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Model Downloader')
+    parser.add_argument('--model_dir', type=str, default=DEFAULT_MODEL_DIR, help='Directory for the models')
+    parser.add_argument('--url', type=str, default=DEFAULT_URL, help='URL for downloading models')
+    args = parser.parse_args()
+
+    URL = args.url
+    ensure_model_exists(args.model_dir)


### PR DESCRIPTION
To follow up on https://github.com/R2D2FISH/glados-tts/issues/14 I added a script to download the models using github releases. However I admit I added quite a lot of "unrelated niceties" which I don't mind removing if you don't want them.

Some things to note:
1. The download link for the models is currently DEFAULT_URL = "https://github.com/nalf3in/glados-tts/releases/download/v0.1.0-alpha/. If you make a github release I would be happy to change it to your repo's release instead
2. I made some changes in glados.py so external programs could specify a specific model_dir or if they want logging to be enabled